### PR TITLE
fix: remove hardcoded Go version and use go.mod for versioning

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  GO_VERSION: "1.25.1"
-
 jobs:
   go-test:
     runs-on: ubuntu-latest
@@ -19,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Run tests
         run: go tool task test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+*"
 
 env:
-  GO_VERSION: "1.25.1"
   PROJECT_NAME: "arduino-flasher-cli"
   DIST_DIR: build
 
@@ -50,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Build Binary
         run: go tool task build


### PR DESCRIPTION
### Motivation
The Go version is redundantly defined in the workflows and in the go.mod file. 

### Change description
Use the go directive of the go.mod file as a single point of Go versioning. Doing that makes it easier to bump the project Go version.

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
