### PR TITLE
chore: update release tag pattern and enhance release task 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 env:
   PROJECT_NAME: "arduino-flasher-cli"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -81,6 +81,17 @@ tasks:
       - test -f ./updater/artifacts/resources_windows_amd64/qdl.exe
     cmd: sh ./updater/artifacts/download_resources.sh
 
+  release:
+    desc: Create a tag on the current commit and push it to the remote to create the release
+    cmds:
+      - |
+          if [ -z "{{.CLI_ARGS}}" ]; then
+            echo "Error: Version argument is required. Usage: task release -- <version>"
+            exit 1
+          fi
+      - git tag -a "{{.CLI_ARGS}}" -m "Release {{.CLI_ARGS}}"
+      - git push origin "{{.CLI_ARGS}}"
+
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies-task/Taskfile.yml
   general:cache-dep-licenses:
     desc: Cache dependency license metadata


### PR DESCRIPTION
## Motivation
The releases did not have a `v` prefix

### Change description
- trigger a release only if the tag has a `v` prefix
- add a task command to create and push a tag to trigger a release `task release -- v0.1.2`

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
