### PR TITLE
Revert `task` changes in `release` workflow and install it using github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,14 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install Taskfile
+        uses: arduino/setup-task@v2
+        with:
+          version: "3.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build Binary
-        run: go tool task build
+        run: task build
         env:
           GOARCH: ${{ matrix.arch }}
           GOOS: ${{ matrix.os }}


### PR DESCRIPTION
### Motivation
```
- name: Build Binary
  run: go tool task build
  env:
    GOARCH: ${{ matrix.arch }}
    GOOS: ${{ matrix.os }}
```
It seems that we cannot use `go tool task` and cross-compilation this way. We are reverting the change temporarily, while we discuss the possibility to switch to the [DistTask](https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/release-go-crosscompile-task.md#assets) approach or something else.
<!-- Why this pull request? -->

### Change description
Partially revert #6 
<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
