### PR TITLE
feat: add download command

### DIFF
--- a/download.go
+++ b/download.go
@@ -1,0 +1,58 @@
+// This file is part of arduino-flasher-cli.
+//
+// Copyright 2025 ARDUINO SA (http://www.arduino.cc/)
+//
+// This software is released under the GNU General Public License version 3,
+// which covers the main part of arduino-flasher-cli.
+// The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to
+// modify or otherwise use the software for commercial activities involving the
+// Arduino software without disclosing the source code of your own applications.
+// To purchase a commercial license, send an email to license@arduino.cc.
+
+package main
+
+import (
+	"os"
+
+	"github.com/arduino/go-paths-helper"
+	"github.com/spf13/cobra"
+
+	"github.com/arduino/arduino-flasher-cli/feedback"
+	"github.com/arduino/arduino-flasher-cli/i18n"
+	"github.com/arduino/arduino-flasher-cli/updater"
+)
+
+func newDownloadCmd() *cobra.Command {
+	var destDir string
+	cmd := &cobra.Command{
+		Use:   "download",
+		Short: "Download a Linux image to the specified path",
+		Args:  cobra.ExactArgs(1),
+		Example: " " + os.Args[0] + " download latest\n" +
+			" " + os.Args[0] + " download latest --dest-dir /tmp\n",
+		Run: func(cmd *cobra.Command, args []string) {
+			runDownloadCommand(args, destDir)
+		},
+	}
+	cmd.Flags().StringVar(&destDir, "dest-dir", ".", "Path to the directory in which the image will be downloaded")
+
+	return cmd
+}
+
+func runDownloadCommand(args []string, destDir string) {
+	targetVersion := args[0]
+	downloadPath := paths.New(destDir)
+	if !downloadPath.IsDir() {
+		feedback.Fatal(i18n.Tr("error: %s is not a directory", destDir), feedback.ErrBadArgument)
+	}
+
+	client := updater.NewClient()
+	_, _, err := updater.DownloadImage(client, targetVersion, nil, true, downloadPath)
+	if err != nil {
+		feedback.Fatal(i18n.Tr("error downloading the image: %v", err), feedback.ErrBadArgument)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 		newFlashCmd(),
 		newInstallDriversCmd(),
 		newListCmd(),
+		newDownloadCmd(),
 		&cobra.Command{
 			Use:   "version",
 			Short: "Print the version number of Arduino Flasher CLI",

--- a/updater/download_image.go
+++ b/updater/download_image.go
@@ -47,7 +47,7 @@ type Release struct {
 type DownloadConfirmCB func(target string) (bool, error)
 
 func DownloadAndExtract(client *Client, targetVersion string, upgradeConfirmCb DownloadConfirmCB, forceYes bool) (*paths.Path, string, error) {
-	tmpZip, version, err := DownloadImage(client, targetVersion, upgradeConfirmCb, forceYes)
+	tmpZip, version, err := DownloadImage(client, targetVersion, upgradeConfirmCb, forceYes, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("error downloading the image: %v", err)
 	}
@@ -69,7 +69,7 @@ func DownloadAndExtract(client *Client, targetVersion string, upgradeConfirmCb D
 	return imagePath, version, nil
 }
 
-func DownloadImage(client *Client, targetVersion string, upgradeConfirmCb DownloadConfirmCB, forceYes bool) (*paths.Path, string, error) {
+func DownloadImage(client *Client, targetVersion string, upgradeConfirmCb DownloadConfirmCB, forceYes bool, downloadPath *paths.Path) (*paths.Path, string, error) {
 	var err error
 
 	feedback.Print(i18n.Tr("Checking for Debian image releases"))
@@ -112,12 +112,14 @@ func DownloadImage(client *Client, targetVersion string, upgradeConfirmCb Downlo
 	defer download.Close()
 
 	// Download the zip
-	temp, err := GetTempDir("download-")
-	if err != nil {
-		return nil, "", fmt.Errorf("could not create temporary download directory: %w", err)
+	if downloadPath == nil {
+		downloadPath, err = GetTempDir("download-")
+		if err != nil {
+			return nil, "", fmt.Errorf("could not create temporary download directory: %w", err)
+		}
 	}
 
-	tmpZip := temp.Join("update.tar.zst")
+	tmpZip := downloadPath.Join("arduino-unoq-debian-image-" + rel.Version + ".tar.zst")
 	tmpZipFile, err := tmpZip.Create()
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
### Motivation
It could be useful to download and save a Debian image, so that it can be flashed multiple times or saved as a back-up.
<!-- Why this pull request? -->

### Change description
The `download` command has been added. It allows the user to download and store the selected Debian image. By default, it downloads the archive to the current directory, but a different path can be specified using the `--dest-dir` flag.
```
$ ./arduino-flasher-cli download latest

$ ./arduino-flasher-cli download latest --dest-dir /different/download/path
```

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] PR title and description are properly filled.
- [x] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
