### PR TITLE
fix: remove `v` version prefix from downloadable archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           VERSION=${GITHUB_REF##*/}
           VERSION=${VERSION#v}
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "RELEASE_NAME=${{ env.PROJECT_NAME }}-${VERSION}-${{ matrix.os }}-${{ matrix.arch }}" >> $GITHUB_ENV
         env:
           GITHUB_REF: ${{ github.ref }}


### PR DESCRIPTION
### Motivation
Version in archive files should not be prefixed by `v`.
<!-- Why this pull request? -->

### Change description
Remove `v` version prefix from downloadable archives.
<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] PR title and description are properly filled.
- [x] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
