### PR TITLE
chore: improve download command feedback to the user

### DIFF
--- a/download.go
+++ b/download.go
@@ -34,6 +34,7 @@ func newDownloadCmd() *cobra.Command {
 		Short: "Download a Linux image to the specified path",
 		Args:  cobra.ExactArgs(1),
 		Example: " " + os.Args[0] + " download latest\n" +
+			" " + os.Args[0] + " download 20251024-412\n" +
 			" " + os.Args[0] + " download latest --dest-dir /tmp\n",
 		Run: func(cmd *cobra.Command, args []string) {
 			runDownloadCommand(cmd.Context(), args, destDir)
@@ -52,8 +53,10 @@ func runDownloadCommand(ctx context.Context, args []string, destDir string) {
 	}
 
 	client := updater.NewClient()
-	_, _, err := updater.DownloadImage(ctx, client, targetVersion, nil, true, downloadPath)
+	downloadPath, _, err := updater.DownloadImage(ctx, client, targetVersion, nil, true, downloadPath)
 	if err != nil {
 		feedback.Fatal(i18n.Tr("error downloading the image: %v", err), feedback.ErrBadArgument)
 	}
+	pathAbs, _ := downloadPath.Abs()
+	feedback.Print(i18n.Tr("\nDebian image successfully downloaded: %s", pathAbs.String()))
 }

--- a/updater/download_image.go
+++ b/updater/download_image.go
@@ -135,8 +135,6 @@ func DownloadImage(ctx context.Context, client *Client, targetVersion string, up
 		return nil, "", fmt.Errorf("bad hash: %x (expected %x)", s, sha256Byte)
 	}
 
-	feedback.Print(i18n.Tr("Download of Debian image completed"))
-
 	return tmpZip, rel.Version, nil
 }
 


### PR DESCRIPTION
### Motivation
Improve download command feedback to the user.
<!-- Why this pull request? -->

### Change description
Added an example of command's usage and print where the image has been downloaded, to make future uses of the `flash` command easier.
<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] PR title and description are properly filled.
- [x] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
