### PR TITLE
chore: improve `flash` warning readability

### DIFF
--- a/cmd/arduino-flasher-cli/flash/flash.go
+++ b/cmd/arduino-flasher-cli/flash/flash.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/arduino/go-paths-helper"
 	runas "github.com/arduino/go-windows-runas"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/arduino/arduino-flasher-cli/cmd/feedback"
@@ -98,7 +99,7 @@ func runFlashCommand(ctx context.Context, args []string, forceYes bool, preserve
 	}
 
 	if !forceYes && !preserveUser {
-		feedback.Print("\nWARNING: flashing a new Linux image on the board will erase any existing data you have on it.")
+		feedback.Print(color.RedString("\nWARNING: flashing a new Linux image will erase any existing data that you have on the board.\n"))
 		feedback.Printf("Do you want to proceed and flash %s on the board? (yes/no)", args[0])
 
 		var yesInput string

--- a/internal/updater/flasher.go
+++ b/internal/updater/flasher.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/arduino/go-paths-helper"
+	"github.com/fatih/color"
 	"github.com/shirou/gopsutil/v4/disk"
 
 	"github.com/arduino/arduino-flasher-cli/cmd/feedback"
@@ -140,8 +141,8 @@ func FlashBoard(ctx context.Context, downloadedImagePath string, version string,
 				if errT != nil {
 					warnStr = errT.Error()
 				}
-				feedback.Printf("\nWARNING: %s.", warnStr)
-				feedback.Printf("Do you want to proceed and flash %s on the board, erasing any existing data you have on it? (yes/no)", target)
+				feedback.Print(color.RedString("\nWARNING: %s. It will not be possible to preserve your data.\n", warnStr))
+				feedback.Printf("Do you want to proceed and flash %s on the board? (yes/no)", target)
 
 				var yesInput string
 				_, err := fmt.Scanf("%s\n", &yesInput)


### PR DESCRIPTION
### Motivation
The warning could be missed while running the `flash` command.
<!-- Why this pull request? -->

### Change description
Highlight the warning in red and make it stand-out from the output.
<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
