### PR TITLE
fix: daemon mode with json format error

### DIFF
--- a/internal/updater/flasher.go
+++ b/internal/updater/flasher.go
@@ -137,11 +137,6 @@ func FlashBoard(ctx context.Context, downloadedImagePath *paths.Path, version st
 		return err
 	}
 
-	stdout, _, err := feedback.DirectStreams()
-	if err != nil {
-		return err
-	}
-
 	rawProgram := "rawprogram0.xml"
 	if preserveUser {
 		if errT := checkBoardGPTTable(ctx, qdlPath, flashDir); errT == nil && flashDir.Join("rawprogram0.nouser.xml").Exist() {
@@ -186,10 +181,9 @@ func FlashBoard(ctx context.Context, downloadedImagePath *paths.Path, version st
 	// Setting the directory is needed because rawprogram0.xml contains relative file paths
 	cmd.SetDir(flashDir.String())
 
-	w := stdout
 	if callback != nil {
 		progress := 0
-		w = helper.NewCallbackWriter(func(line string) {
+		w := helper.NewCallbackWriter(func(line string) {
 			parsedLine := parseQdlLogLine(line)
 
 			switch parsedLine.Op {
@@ -208,9 +202,17 @@ func FlashBoard(ctx context.Context, downloadedImagePath *paths.Path, version st
 				})
 			}
 		})
+		cmd.RedirectStderrTo(w)
+		cmd.RedirectStdoutTo(w)
+	} else {
+		stdout, _, err := feedback.DirectStreams()
+		if err != nil {
+			return err
+		}
+		cmd.RedirectStderrTo(stdout)
+		cmd.RedirectStdoutTo(stdout)
 	}
-	cmd.RedirectStderrTo(w)
-	cmd.RedirectStdoutTo(w)
+
 	if err := cmd.RunWithinContext(ctx); err != nil {
 		return err
 	}

--- a/service/service_flash.go
+++ b/service/service_flash.go
@@ -116,6 +116,8 @@ func (s *flasherServerImpl) Flash(req *flasher.FlashRequest, stream flasher.Flas
 				Progress: int64(fe.Progress),
 				Total:    int64(fe.Total),
 			})
+		default:
+			panic("unknown flash event type")
 		}
 
 	}); err != nil {


### PR DESCRIPTION
### Motivation

Running the daemon with JSON format fails with the error  `available only in text format`.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
