### PR TITLE
Print a message in case of qdl exit 1 on Linux systems.

### DIFF
--- a/cmd/arduino-flasher-cli/flash/flash.go
+++ b/cmd/arduino-flasher-cli/flash/flash.go
@@ -99,7 +99,7 @@ func runFlashCommand(ctx context.Context, args []string, forceYes bool, preserve
 	}
 
 	if !forceYes && !preserveUser {
-		feedback.Print(color.RedString("\nWARNING: flashing a new Linux image will erase any existing data that you have on the board\n"))
+		feedback.Print(color.RedString("\nWARNING: flashing a new Linux image will erase any existing data that you have on the board.\n"))
 		feedback.Printf("Do you want to proceed and flash %s on the board? (yes/no)", args[0])
 
 		var yesInput string

--- a/internal/updater/flasher.go
+++ b/internal/updater/flasher.go
@@ -191,7 +191,7 @@ func FlashBoard(ctx context.Context, downloadedImagePath *paths.Path, version st
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			if exitErr.ExitCode() == 1 && runtime.GOOS == "linux" {
-				return fmt.Errorf("exit status %d\nPossible qcserial issue?\nSee https://docs.arduino.cc/tutorials/uno-q/update-image/#fixing-qcserial-issue-linux-only for details.", exitErr.ExitCode())
+				return fmt.Errorf("exit status %d\nPossible qcserial issue?\nSee https://docs.arduino.cc/tutorials/uno-q/update-image/#fixing-qcserial-issue-linux-only for details", exitErr.ExitCode())
 			}
 		}
 		return err


### PR DESCRIPTION
### Motivation

In some Linux systems, the arduino-flasher-cli could exit with an error (code 1) right before flashing.

### Change description

This pr get the qdl exit code in case of error, if the exit error is 1 and the os is Linux print a message pointing the user to the possible issue: https://docs.arduino.cc/tutorials/uno-q/update-image/#fixing-qcserial-issue-linux-only

### Additional Notes

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
