### PR TITLE
feat(grpc): remove wait for edl device

### DIFF
--- a/internal/updater/artifacts/download_resources.sh
+++ b/internal/updater/artifacts/download_resources.sh
@@ -5,7 +5,7 @@ set -e
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 REPO="arduino/qdl-packing"
-TAG="add-list-command-25"
+TAG="v2.2-22"
 
 # Remove existing resource directories if they exist
 rm -rf $BASE_DIR/resources_*

--- a/internal/updater/flasher.go
+++ b/internal/updater/flasher.go
@@ -20,12 +20,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/arduino/go-paths-helper"
 	"github.com/fatih/color"
@@ -288,36 +286,4 @@ func checkBoardGPTTable(ctx context.Context, qdlPath, flashDir *paths.Path) erro
 	}
 
 	return nil
-}
-
-// WantForQdlDevice waits for a QDL device to be connected.
-// This is like and hack because QDL does not have a specific command to wait for a device,
-// so we use the read command with a dummy ELF and XML file to detect when a device is connected.
-func WaitForQdlDevice(ctx context.Context) error {
-	qdlPath, cleanup, err := installQdl()
-	if err != nil {
-		return err
-	}
-	defer cleanup()
-
-	for {
-		cmd, err := paths.NewProcess(nil, qdlPath.String(), "--list")
-		if err != nil {
-			return err
-		}
-		if out, err := cmd.RunAndCaptureCombinedOutput(ctx); err != nil {
-			slog.Debug("wait for qdl device command exit", "out", string(out), "err", err)
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) {
-				if exitErr.ExitCode() != 1 {
-					return fmt.Errorf("error waiting for QDL device: %w: %s", err, out)
-				}
-			}
-		} else {
-			slog.Debug("qdl device detected", "out", string(out))
-			return nil
-		}
-
-		time.Sleep(1 * time.Second)
-	}
 }

--- a/service/service_flash.go
+++ b/service/service_flash.go
@@ -67,10 +67,6 @@ func (s *flasherServerImpl) Flash(req *flasher.FlashRequest, stream flasher.Flas
 		}
 	}
 
-	if err := updater.WaitForQdlDevice(ctx); err != nil {
-		return fmt.Errorf("could not find connected Arduino Uno QDL device: %w", err)
-	}
-
 	rel, err := client.GetReleaseByVersion(ctx, req.GetVersion())
 	if err != nil {
 		return fmt.Errorf("could not get release info: %w", err)


### PR DESCRIPTION
### Motivation

The grpc flash operation will not wait for the device before starting the download.

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
