### PR TITLE
feat: remove arduino-deb reference

### DIFF
--- a/cmd/arduino-flasher-cli/list/list.go
+++ b/cmd/arduino-flasher-cli/list/list.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/arduino/arduino-flasher-cli/cmd/feedback"
 	"github.com/arduino/arduino-flasher-cli/cmd/i18n"
+	"github.com/arduino/arduino-flasher-cli/internal/registry"
 	"github.com/arduino/arduino-flasher-cli/internal/tablestyle"
-	"github.com/arduino/arduino-flasher-cli/internal/updater"
 )
 
 func NewListCmd() *cobra.Command {
@@ -40,7 +40,7 @@ func NewListCmd() *cobra.Command {
 }
 
 func runListCommand(ctx context.Context) {
-	client := updater.NewClient()
+	client := registry.NewClient()
 
 	manifest, err := client.GetInfoManifest(ctx)
 	if err != nil {
@@ -51,8 +51,8 @@ func runListCommand(ctx context.Context) {
 }
 
 type listResult struct {
-	Latest   updater.Release   `json:"latest"`
-	Releases []updater.Release `json:"releases"`
+	Latest   registry.Release   `json:"latest"`
+	Releases []registry.Release `json:"releases"`
 }
 
 // Data implements Result interface

--- a/internal/registry/http_client.go
+++ b/internal/registry/http_client.go
@@ -13,7 +13,7 @@
 // Arduino software without disclosing the source code of your own applications.
 // To purchase a commercial license, send an email to license@arduino.cc.
 
-package updater
+package registry
 
 import (
 	"bytes"
@@ -26,6 +26,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"path"
 	"time"
 
 	"github.com/arduino/go-paths-helper"
@@ -39,6 +40,18 @@ import (
 var baseURL = f.Must(url.Parse("https://downloads.arduino.cc"))
 
 const pathRelease = "debian-im/Stable"
+
+type Manifest struct {
+	Latest   Release   `json:"latest"`
+	Releases []Release `json:"releases"`
+}
+
+type Release struct {
+	Version  string `json:"version"`
+	Url      string `json:"url"`
+	Sha256   string `json:"sha256"`
+	FileName string `json:"-"`
+}
 
 // Client holds the base URL, command name, allows custom HTTP client, and optional headers.
 type Client struct {
@@ -109,6 +122,27 @@ func (c *Client) GetInfoManifest(ctx context.Context) (Manifest, error) {
 	} else if len(sha256Byte) != sha256.Size {
 		return Manifest{}, fmt.Errorf("bad sha256sum in manifest: got %d bytes", len(sha256Byte))
 	}
+
+	getFileName := func(rel Release) (string, error) {
+		url, err := url.Parse(rel.Url)
+		if err != nil {
+			return "", fmt.Errorf("invalid URL in manifest for release %s: %w", rel.Version, err)
+		}
+		return path.Base(url.Path), nil
+	}
+	res.Latest.FileName, err = getFileName(res.Latest)
+	if err != nil {
+		return Manifest{}, err
+	}
+	for i := range res.Releases {
+		r := &res.Releases[i]
+		url, err := url.Parse(r.Url)
+		if err != nil {
+			return Manifest{}, fmt.Errorf("invalid URL in manifest for release %s: %w", r.Version, err)
+		}
+		r.FileName = path.Base(url.Path)
+	}
+
 	return res, nil
 }
 
@@ -136,16 +170,22 @@ type downloadCallback func(current, total int64)
 // DownloadFile downloads a file from a URL into the specified path. An optional config and options may be passed (or nil to use the defaults).
 // A DownloadProgressCB callback function must be passed to monitor download progress.
 // If a not empty queryParameter is passed, it is appended to the URL for analysis purposes.
-func (c *Client) DownloadFile(ctx context.Context, path *paths.Path, rel Release, cb downloadCallback) (returnedError error) {
-	f.Assert(path.NotExist() || path.IsNotDir(), "path must not be a directory")
+func (c *Client) DownloadFile(ctx context.Context, basePath *paths.Path, rel Release, cb downloadCallback) (*paths.Path, error) {
+	f.Assert(basePath.IsDir(), "path must be a directory")
 
 	// Check if there is enough free disk space before downloading and extracting an image
-	dk, err := disk.Usage(path.Parent().String())
+	dk, err := disk.Usage(basePath.String())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	d, err := downloader.DownloadWithConfigAndContext(ctx, path.String(), rel.Url, downloader.Config{
+	fmt.Printf("release: %+v\n", rel)
+
+	filePath := basePath.Join(rel.FileName)
+
+	fmt.Printf(filePath.String())
+
+	d, err := downloader.DownloadWithConfigAndContext(ctx, filePath.String(), rel.Url, downloader.Config{
 		HttpClient:   *c.HTTPClient,
 		ExtraHeaders: maps.Clone(c.Headers),
 		AcceptFunc: func(head *http.Response) error {
@@ -156,39 +196,39 @@ func (c *Client) DownloadFile(ctx context.Context, path *paths.Path, rel Release
 		},
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = d.RunAndPoll(func(downloaded int64) {
 		cb(downloaded, d.Size())
 	}, 250*time.Millisecond)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// The URL is not reachable for some reason
 	if d.Resp.StatusCode >= 400 && d.Resp.StatusCode <= 599 {
 		msg := i18n.Tr("Server responded with: %s", d.Resp.Status)
-		return fmt.Errorf("%s", msg)
+		return nil, fmt.Errorf("%s", msg)
 	}
 
 	// Check the hash
 	checksum := sha256.New()
-	tmpZipFile, err := path.Open()
+	tmpZipFile, err := filePath.Open()
 	if err != nil {
-		return fmt.Errorf("could not open archive: %w", err)
+		return nil, fmt.Errorf("could not open archive: %w", err)
 	}
 	defer tmpZipFile.Close()
 
 	_, err = io.Copy(checksum, tmpZipFile)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if sha256Byte, err := hex.DecodeString(rel.Sha256); err != nil {
-		return fmt.Errorf("could not convert sha256 from hex to bytes: %w", err)
+		return nil, fmt.Errorf("could not convert sha256 from hex to bytes: %w", err)
 	} else if s := checksum.Sum(nil); !bytes.Equal(s, sha256Byte) {
-		return fmt.Errorf("bad hash: %x (expected %x)", s, sha256Byte)
+		return nil, fmt.Errorf("bad hash: %x (expected %x)", s, sha256Byte)
 	}
 
-	return nil
+	return filePath, nil
 }

--- a/internal/registry/http_client.go
+++ b/internal/registry/http_client.go
@@ -179,12 +179,7 @@ func (c *Client) DownloadFile(ctx context.Context, basePath *paths.Path, rel Rel
 		return nil, err
 	}
 
-	fmt.Printf("release: %+v\n", rel)
-
 	filePath := basePath.Join(rel.FileName)
-
-	fmt.Printf(filePath.String())
-
 	d, err := downloader.DownloadWithConfigAndContext(ctx, filePath.String(), rel.Url, downloader.Config{
 		HttpClient:   *c.HTTPClient,
 		ExtraHeaders: maps.Clone(c.Headers),

--- a/internal/registry/http_client.go
+++ b/internal/registry/http_client.go
@@ -130,17 +130,15 @@ func (c *Client) GetInfoManifest(ctx context.Context) (Manifest, error) {
 		}
 		return path.Base(url.Path), nil
 	}
-	res.Latest.FileName, err = getFileName(res.Latest)
-	if err != nil {
+	if res.Latest.FileName, err = getFileName(res.Latest); err != nil {
 		return Manifest{}, err
 	}
 	for i := range res.Releases {
-		r := &res.Releases[i]
-		url, err := url.Parse(r.Url)
-		if err != nil {
-			return Manifest{}, fmt.Errorf("invalid URL in manifest for release %s: %w", r.Version, err)
+		if name, err := getFileName(res.Releases[i]); err != nil {
+			return Manifest{}, err
+		} else {
+			res.Releases[i].FileName = name
 		}
-		r.FileName = path.Base(url.Path)
 	}
 
 	return res, nil

--- a/internal/updater/download_image.go
+++ b/internal/updater/download_image.go
@@ -26,48 +26,35 @@ import (
 
 	"github.com/arduino/arduino-flasher-cli/cmd/feedback"
 	"github.com/arduino/arduino-flasher-cli/cmd/i18n"
+	"github.com/arduino/arduino-flasher-cli/internal/registry"
 )
-
-type Manifest struct {
-	Latest   Release   `json:"latest"`
-	Releases []Release `json:"releases"`
-}
-
-type Release struct {
-	Version string `json:"version"`
-	Url     string `json:"url"`
-	Sha256  string `json:"sha256"`
-}
 
 // DownloadConfirmCB is a function that is called when a Debian image is ready to be downloaded.
 type DownloadConfirmCB func(target string) (bool, error)
 
-func DownloadAndExtract(ctx context.Context, targetVersion string, temp *paths.Path) (*paths.Path, string, error) {
+func DownloadAndExtract(ctx context.Context, targetVersion string, temp *paths.Path) (string, error) {
 	tmpZip, version, err := DownloadImage(ctx, targetVersion, temp)
 	if err != nil {
-		return nil, "", fmt.Errorf("error downloading the image: %v", err)
+		return "", fmt.Errorf("error downloading the image: %v", err)
 	}
 
-	err = ExtractImage(ctx, tmpZip, tmpZip.Parent())
+	err = ExtractImage(ctx, tmpZip, temp)
 	if err != nil {
-		return nil, "", fmt.Errorf("error extracting the image: %v", err)
+		return "", fmt.Errorf("error extracting the image: %v", err)
 	}
 
-	imagePath := tmpZip.Parent().Join("arduino-unoq-debian-image-" + version)
 	if targetVersion == "latest" {
 		version += "(latest)"
 	}
-	return imagePath, version, nil
+	return version, nil
 }
 
 func DownloadImage(ctx context.Context, targetVersion string, downloadPath *paths.Path) (*paths.Path, string, error) {
-	client := NewClient()
+	client := registry.NewClient()
 	rel, err := client.GetReleaseByVersion(ctx, targetVersion)
 	if err != nil {
 		return nil, "", fmt.Errorf("could not get release info: %w", err)
 	}
-
-	tmpZip := downloadPath.Join("arduino-unoq-debian-image-" + rel.Version + ".tar.zst")
 
 	var bar *progressbar.ProgressBar
 	callback := func(current, total int64) {
@@ -79,11 +66,11 @@ func DownloadImage(ctx context.Context, targetVersion string, downloadPath *path
 		}
 		_ = bar.Set64(current)
 	}
-	if err := client.DownloadFile(ctx, tmpZip, rel, callback); err != nil {
+	if tmpZip, err := client.DownloadFile(ctx, downloadPath, rel, callback); err != nil {
 		return nil, "", fmt.Errorf("could not download Debian image: %w", err)
+	} else {
+		return tmpZip, rel.Version, nil
 	}
-
-	return tmpZip, rel.Version, nil
 }
 
 func ExtractImage(ctx context.Context, archive, temp *paths.Path) error {

--- a/internal/updater/flasher.go
+++ b/internal/updater/flasher.go
@@ -58,14 +58,14 @@ func Flash(ctx context.Context, imagePath *paths.Path, version string, forceYes 
 			return fmt.Errorf("download and extraction requires up to %d GiB of free space", DownloadDiskSpace)
 		}
 
-		tempImagePath, v, err := DownloadAndExtract(ctx, version, temp)
+		v, err := DownloadAndExtract(ctx, version, temp)
 
 		if err != nil {
 			return fmt.Errorf("could not download and extract the image: %v", err)
 		}
 
 		version = v
-		imagePath = tempImagePath
+		imagePath = temp
 	} else if !imagePath.IsDir() {
 		temp, err := SetTempDir("extract-", tempDir)
 		if err != nil {
@@ -87,12 +87,7 @@ func Flash(ctx context.Context, imagePath *paths.Path, version string, forceYes 
 			return fmt.Errorf("error extracting the archive: %v", err)
 		}
 
-		tempContent, err := temp.ReadDir(paths.AndFilter(paths.FilterDirectories(), paths.FilterPrefixes("arduino-unoq-debian-image-")))
-		if err != nil {
-			return fmt.Errorf("could not find Debian image directory: %v", err)
-		}
-
-		imagePath = tempContent[0]
+		imagePath = temp
 	}
 
 	return FlashBoard(ctx, "", imagePath, version, preserveUser, nil)

--- a/service/service_flash.go
+++ b/service/service_flash.go
@@ -21,6 +21,7 @@ import (
 	"github.com/arduino/go-paths-helper"
 	"github.com/codeclysm/extract/v4"
 
+	"github.com/arduino/arduino-flasher-cli/internal/registry"
 	"github.com/arduino/arduino-flasher-cli/internal/updater"
 	flasher "github.com/arduino/arduino-flasher-cli/rpc/cc/arduino/flasher/v1"
 )
@@ -58,7 +59,7 @@ func (s *flasherServerImpl) Flash(req *flasher.FlashRequest, stream flasher.Flas
 		})
 	}
 
-	client := updater.NewClient()
+	client := registry.NewClient()
 
 	tmpPath := paths.New(req.GetTempPath())
 	rmTempPath := func() {
@@ -72,10 +73,9 @@ func (s *flasherServerImpl) Flash(req *flasher.FlashRequest, stream flasher.Flas
 		return fmt.Errorf("could not get release info: %w", err)
 	}
 
-	tmpZip := tmpPath.Join("arduino-unoq-debian-image-" + rel.Version + ".tar.zst")
-
 	downloadCB.Start(rel.Url, rel.Version)
-	if err := client.DownloadFile(ctx, tmpZip, rel, downloadCB.Update); err != nil {
+	tmpZip, err := client.DownloadFile(ctx, tmpPath, rel, downloadCB.Update)
+	if err != nil {
 		// FIXME: Maybe this is redundant?
 		downloadCB.End(false, err.Error())
 		return err

--- a/service/service_list.go
+++ b/service/service_list.go
@@ -22,19 +22,19 @@ import (
 
 	"go.bug.st/f"
 
-	"github.com/arduino/arduino-flasher-cli/internal/updater"
+	"github.com/arduino/arduino-flasher-cli/internal/registry"
 	flasher "github.com/arduino/arduino-flasher-cli/rpc/cc/arduino/flasher/v1"
 )
 
 func (s *flasherServerImpl) List(ctx context.Context, req *flasher.ListRequest) (*flasher.ListResponse, error) {
-	client := updater.NewClient()
+	client := registry.NewClient()
 
 	manifest, err := client.GetInfoManifest(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	releases := f.Map(manifest.Releases, func(r updater.Release) *flasher.Release {
+	releases := f.Map(manifest.Releases, func(r registry.Release) *flasher.Release {
 		return &flasher.Release{
 			BuildId: r.Version,
 			Latest:  r.Version == manifest.Latest.Version,


### PR DESCRIPTION
### Motivation

Allow flashing of every archive with a `flash` dir inside.

### Change description

Remove explicit reference to `arduino-unoq-debian-image`

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
