### PR TITLE
fix: force hex conversion to have 8 digits

### DIFF
--- a/internal/types/serial/serial.go
+++ b/internal/types/serial/serial.go
@@ -21,5 +21,5 @@ func FromHex(hexStr string) (Serial, error) {
 }
 
 func (s Serial) Hex() string {
-	return strings.ToUpper(fmt.Sprintf("%08x", s.num))
+ return fmt.Sprintf("%08X", s.num)
 }

--- a/internal/types/serial/serial.go
+++ b/internal/types/serial/serial.go
@@ -1,6 +1,7 @@
 package serial
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -20,5 +21,5 @@ func FromHex(hexStr string) (Serial, error) {
 }
 
 func (s Serial) Hex() string {
-	return strings.ToUpper(strconv.FormatInt(s.num, 16))
+	return strings.ToUpper(fmt.Sprintf("%08x", s.num))
 }

--- a/internal/types/serial/serial.go
+++ b/internal/types/serial/serial.go
@@ -3,7 +3,6 @@ package serial
 import (
 	"fmt"
 	"strconv"
-	"strings"
 )
 
 type Serial struct {
@@ -21,5 +20,5 @@ func FromHex(hexStr string) (Serial, error) {
 }
 
 func (s Serial) Hex() string {
- return fmt.Sprintf("%08X", s.num)
+	return fmt.Sprintf("%08X", s.num)
 }

--- a/internal/types/serial/serial_test.go
+++ b/internal/types/serial/serial_test.go
@@ -99,12 +99,17 @@ func TestSerialHex(t *testing.T) {
 		{
 			name:  "Convert to hexadecimal",
 			input: Serial{num: 123456789},
-			want:  "75BCD15",
+			want:  "075BCD15",
+		},
+		{
+			name:  "Convert to hexadecimal (no padding)",
+			input: Serial{num: 987654321},
+			want:  "3ADE68B1",
 		},
 		{
 			name:  "Convert zero",
 			input: Serial{num: 0},
-			want:  "0",
+			want:  "00000000",
 		},
 	}
 


### PR DESCRIPTION
### Motivation
Hexadecimal serial numbers when the UNO Q board is in EDL mode have 8 digits. Add left padding when the conversion from integer generates fewer digits.
<!-- Why this pull request? -->

### Change description
Add left padding when the conversion from integer generates fewer digits.
<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] PR title and description are properly filled.
- [x] Changes will be merged in `main`.
- [x] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
