### PR TITLE
chore: change archive name extension for better clarity

### DIFF
--- a/cmd/arduino-flasher-cli/flash/flash.go
+++ b/cmd/arduino-flasher-cli/flash/flash.go
@@ -58,7 +58,7 @@ NOTE: On Windows, required drivers are automatically installed with elevated pri
 			" " + os.Args[0] + " flash unoq\n" +
 			" " + os.Args[0] + " flash unoq --version 20250915-173\n" +
 			" " + os.Args[0] + " flash unoq ./my-image.tar.zst\n" +
-			" " + os.Args[0] + " flash unoq /path/to/debian-image.tar.xz \n" +
+			" " + os.Args[0] + " flash unoq /path/to/debian-image.tar.zst \n" +
 			" " + os.Args[0] + " flash unoq /path/to/arduino-unoq-debian-image-20250915-173 \n" +
 			" " + os.Args[0] + " flash unoq --temp-dir /path/to/custom/tempDir \n" +
 			" " + os.Args[0] + " flash unoq --preserve-user \n" +


### PR DESCRIPTION
### Motivation
Downloaded images have a `.tar.zst` estension. The flasher can handle different archives but for clarity purposes the `help` message should use the official one.
<!-- Why this pull request? -->

### Change description

<!-- What does your code do? -->

### Additional Notes

<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] PR title and description are properly filled.
- [ ] Changes will be merged in `main`.
- [ ] Changes are covered by tests.
- [ ] Logging is meaningful in case of troubleshooting.
